### PR TITLE
大佬，发现您的项目引入了org.apache.xmlbeans:xmlbeans@2.6.0组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.example</groupId>
@@ -51,7 +49,7 @@
         <dependency>
             <groupId>org.apache.xmlbeans</groupId>
             <artifactId>xmlbeans</artifactId>
-            <version>2.6.0</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>dom4j</groupId>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Apache Xmlbeans输入验证错误漏洞
缺陷组件：org.apache.xmlbeans:xmlbeans@2.6.0
漏洞编号：CVE-2021-23926
漏洞描述：Apache Xmlbeans是Apache基金会的一款用于支持Java与XMl格式数据进行交互的软件。
Apache Xmlbeans up to version 2.6.0存在输入验证错误漏洞，该漏洞源于未能设置保护用户免受恶意XML输入伤害所需的属性。攻击者可能利用此缺陷漏洞实施可能的XML实体扩展攻击。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2021-03544
影响范围：(∞, 3.0.0)
最小修复版本：3.0.0
缺陷组件引入路径：org.example:YouYouRobot@1.0-SNAPSHOT->org.apache.xmlbeans:xmlbeans@2.6.0
```
另外我运行这个项目时，IDE的安全插件提示还有107个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p6d9d5